### PR TITLE
[Interactive] Option to simultaneously connect to a client over TCP 

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -63,6 +63,7 @@ def genScenario():
 	nodeHopLimit = []
 	nodeTxts = []
 	gains = []
+	neighborInfo = []
 
 	fig = plt.figure()
 	ax = fig.add_subplot(111)
@@ -140,6 +141,7 @@ def genScenario():
 		nodeRepeater.append(roleButton.value_selected == 'Repeater')
 		nodeHopLimit.append(slider.val)
 		gains.append(float(gain_textbox.text))
+		neighborInfo.append("True")
 		fig.canvas.mpl_disconnect(cid)
 		plt.close()
 	button.on_clicked(submit)
@@ -154,6 +156,7 @@ def genScenario():
 				nodeRepeater.append(roleButton.value_selected == 'Repeater')
 				nodeHopLimit.append(slider.val)
 				gains.append(float(gain_textbox.text))
+				neighborInfo.append("True")
 				# Reset config values
 				roleButton.set_active(1 if conf.router else 0)
 				height_textbox.set_val(conf.HM)
@@ -171,7 +174,7 @@ def genScenario():
 	nodeDict = {n: {'x': nodeX[n], 'y': nodeY[n], 'z': nodeZ[n], \
 		'isRouter': nodeRouter[n], 'isRepeater': nodeRepeater[n], \
 		'hopLimit':nodeHopLimit[n], \
-		'antennaGain': gains[n]} for n in range(len(nodeX))}
+		'antennaGain': gains[n], 'neighborInfo': neighborInfo[n]} for n in range(len(nodeX))}
 	if save:
 		if not os.path.isdir("out"):
 			os.mkdir("out")

--- a/lib/interactive.py
+++ b/lib/interactive.py
@@ -496,7 +496,8 @@ class interactiveSim():
     iface._sendToRadio(toRadio)
 
   def copyPacket(self, packet):
-    print(packet)
+    # print(packet)
+    time.sleep(0.01)
     try:
       if 'simulator' in packet or packet["decoded"]["portnum"] == "SIMULATOR_APP":
         return None

--- a/lib/interactive.py
+++ b/lib/interactive.py
@@ -366,12 +366,11 @@ class interactiveSim():
         exit(1)
       n0 = self.nodes[0]
       dockerClient = docker.from_env()
-      startNode = "./meshtasticd_linux_amd64"
+      startNode = "./meshtasticd_linux_amd64 "
       if self.eraseFlash:
-        startNode += " -e "
+        startNode += "-e "
       if sys.platform == "darwin":
-        self.container = dockerClient.containers.run("meshtastic/device-simulator", \
-          startNode + "-d /home/node"+str(n0.nodeid)+" -h "+str(n0.hwId)+" -p "+str(n0.TCPPort), \
+        self.container = dockerClient.containers.run("meshtastic/device-simulator", startNode + "-d /home/node"+str(n0.nodeid)+" -h "+str(n0.hwId)+" -p "+str(n0.TCPPort), \
           ports=dict(zip((str(n.TCPPort)+'/tcp' for n in self.nodes), (n.TCPPort for n in self.nodes))), detach=True, auto_remove=True, user="root")
         for n in self.nodes[1:]:
           self.container.exec_run("./meshtasticd_linux_amd64 -e -d /home/node"+str(n.nodeid)+" -h "+str(n.hwId)+" -p "+str(n.TCPPort), detach=True, user="root") 
@@ -497,6 +496,7 @@ class interactiveSim():
     iface._sendToRadio(toRadio)
 
   def copyPacket(self, packet):
+    print(packet)
     try:
       if 'simulator' in packet or packet["decoded"]["portnum"] == "SIMULATOR_APP":
         return None

--- a/lib/interactive.py
+++ b/lib/interactive.py
@@ -453,26 +453,7 @@ class interactiveSim():
     if len(data) > mesh_pb2.Constants.DATA_PAYLOAD_LEN:
       raise Exception("Data payload too big")
 
-    if packet["decoded"]["portnum"] == "TEXT_MESSAGE_APP":
-      meshPacket = mesh_pb2.MeshPacket()
-    elif packet["decoded"]["portnum"] == "ROUTING_APP":
-      meshPacket = mesh_pb2.Routing()
-    elif packet["decoded"]["portnum"] == "NODEINFO_APP":
-      meshPacket = mesh_pb2.NodeInfo()
-    elif packet["decoded"]["portnum"] == "POSITION_APP":
-      meshPacket = mesh_pb2.Position()
-    elif packet["decoded"]["portnum"] == "USER_APP":
-      meshPacket = mesh_pb2.User()  
-    elif packet["decoded"]["portnum"] == "ADMIN_APP":
-      meshPacket = admin_pb2.AdminMessage()
-    elif packet["decoded"]["portnum"] == "TELEMETRY_APP":
-      meshPacket = telemetry_pb2.Telemetry()
-    elif packet["decoded"]["portnum"] == "REMOTE_HARDWARE_APP":
-      meshPacket = remote_hardware_pb2.HardwareMessage()
-    elif packet["decoded"]["portnum"] == "NEIGHBORINFO_APP":
-      meshPacket = mesh_pb2.NeighborInfo() 
-    else:
-      meshPacket = mesh_pb2.MeshPacket()
+    meshPacket = mesh_pb2.MeshPacket()
 
     meshPacket.decoded.payload = data
     meshPacket.decoded.portnum = portnums_pb2.SIMULATOR_APP

--- a/lib/interactive.py
+++ b/lib/interactive.py
@@ -369,6 +369,7 @@ class interactiveSim():
       startNode = "./meshtasticd_linux_amd64 "
       if self.eraseFlash:
         startNode += "-e "
+
       if sys.platform == "darwin":
         self.container = dockerClient.containers.run("meshtastic/device-simulator", startNode + "-d /home/node"+str(n0.nodeid)+" -h "+str(n0.hwId)+" -p "+str(n0.TCPPort), \
           ports=dict(zip((str(n.TCPPort)+'/tcp' for n in self.nodes), (n.TCPPort for n in self.nodes))), detach=True, auto_remove=True, user="root")
@@ -378,7 +379,7 @@ class interactiveSim():
       else: 
         self.container = dockerClient.containers.run("meshtastic/device-simulator", \
           "sh -c '" + startNode + "-d /home/node"+str(n0.nodeid)+" -h "+str(n0.hwId)+" -p "+str(n0.TCPPort)+" > /home/out_"+str(n0.nodeid)+".log'", \
-          ports=dict(zip((str(n.TCPPort)+'/tcp' for n in self.nodes), (n.TCPPort for n in self.nodes))), detach=True, auto_remove=True, user="root")
+          ports=dict(zip((str(n.TCPPort)+'/tcp' for n in self.nodes), (n.TCPPort for n in self.nodes))), detach=True, auto_remove=True, user="root", volumes={"Meshtasticator": {'bind': '/home/', 'mode': 'rw'}})
         for n in self.nodes[1:]:
           self.container.exec_run("sh -c '" + startNode + "-d /home/node"+str(n.nodeid)+" -h "+str(n.hwId)+" -p "+str(n.TCPPort)+" > /home/out_"+str(n.nodeid)+".log'", detach=True, user="root") 
         print("Docker container with name "+str(self.container.name)+" is started.")


### PR DESCRIPTION
Steps to simulate multiple nodes and simultaneously connect Node 0 to a client (currently only tested with https://github.com/ajmcquilkin/meshtastic-network-management-client) using Docker:

- Run `python3 interactiveSim.py --f --d` in a terminal, place some nodes and click 'Start simulation'.
- In the client, use TCP hostname 127.0.0.1 port **4402** and click 'Connect'.

To check whether it is working correctly, type the following in the terminal where you started the interactive simulator:
`DM 1 0 "Hello from node 1"`
The direct message should show up in the client, as Node 0 is connected to it.

This branch currently by default enables the NeighborInfo module, but the nodes have to be restarted for this to take effect. You therefore have to type 'exit' first, close the client, and re-run the scenario using:
`python3 interactiveSim.py --f --d --from-file`
Then reconnect to the client. After a while, the application graph should be built.

